### PR TITLE
Service Installation fails

### DIFF
--- a/Server/pkg/startup_windows.bat
+++ b/Server/pkg/startup_windows.bat
@@ -20,8 +20,8 @@ if '%choice%'=='x' goto :exit
 :addstartup
 cls
 
-if exist %~dp0server_win.exe (
-    reg add HKLM\Software\Microsoft\Windows\CurrentVersion\Run\ /v "%keyname%" /t REG_SZ /d %~dp0server_win.exe
+if exist "%~dp0server_win.exe" (
+    reg add HKLM\Software\Microsoft\Windows\CurrentVersion\Run\ /v "%keyname%" /t REG_SZ /d "%~dp0server_win.exe"
 ) else (
     echo File not found!
 )


### PR DESCRIPTION
Service cant be installed with folder names like `windows_64bit - Kopie ()-2`.