### PR TITLE
Tweek windows startup script

### DIFF
--- a/Server/pkg/startup_windows.bat
+++ b/Server/pkg/startup_windows.bat
@@ -7,7 +7,7 @@ if not "%1"=="am_admin" (powershell start -verb runas '%0' am_admin & exit /b)
 Set keyname=Discord RPC Extension
 
 echo	Discord-RPC-Extension
-echo    1. Add Discord-RPC-Extensionc Program to Startup
+echo    1. Add Discord-RPC-Extension Program to Startup
 echo    2. Remove Discord-RPC-Extension Program From Startup
 echo    3. Exit
 

--- a/Server/pkg/startup_windows.bat
+++ b/Server/pkg/startup_windows.bat
@@ -31,5 +31,7 @@ goto begin
 :delstartup
 cls
 reg delete HKLM\Software\Microsoft\Windows\CurrentVersion\Run\ /v "%keyname%" /f
+:: also delete old key
+reg delete HKLM\Software\Microsoft\Windows\CurrentVersion\Run\ /v "MAL Sync Program" /f
 timeout /t 2 >nul
 goto begin

--- a/Server/pkg/startup_windows.bat
+++ b/Server/pkg/startup_windows.bat
@@ -1,39 +1,35 @@
+@echo off
+
 :begin
 cls
-@echo off
 if not "%1"=="am_admin" (powershell start -verb runas '%0' am_admin & exit /b)
 
-Set keyname=MAL Sync Program
+Set keyname=Discord RPC Extension
 
-echo	MAL-Sync
-echo    1. Add MAL-Sync Program to Startup
-echo    2. Remove MAL-Sync Program From Startup
-echo    x. Exit
+echo	Discord-RPC-Extension
+echo    1. Add Discord-RPC-Extensionc Program to Startup
+echo    2. Remove Discord-RPC-Extension Program From Startup
+echo    3. Exit
 
 set /p choice=  Choose A Service:
 if not '%choice%'== set %choice%=choice:~0,1%
 
 if '%choice%'=='1' goto :addstartup
 if '%choice%'=='2' goto :delstartup
-if '%choice%'=='x' goto :exit
+if '%choice%'=='3' goto :exit
 
 :addstartup
 cls
-
 if exist "%~dp0server_win.exe" (
     reg add HKLM\Software\Microsoft\Windows\CurrentVersion\Run\ /v "%keyname%" /t REG_SZ /d "%~dp0server_win.exe"
 ) else (
-    echo File not found!
+    echo Server file not found!
 )
-
 timeout /t 2 >nul
-
 goto begin
 
 :delstartup
 cls
 reg delete HKLM\Software\Microsoft\Windows\CurrentVersion\Run\ /v "%keyname%" /f
-
 timeout /t 2 >nul
-
 goto begin


### PR DESCRIPTION
Changes I made in this PR:
- Rename registry key and menu options from `MAL-Sync` to `Discord RPC Extension`
- Change `x` (exit) option to `3` (options `1` `2` `x` looks wired)
- Remove couple of newlines to make code more readable