### PR TITLE
Improve `extensions.md`

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,24 +1,21 @@
-## Compatible Extensions
-<table>
-  <tr>
-    <td><!--Title-->Discord-RPC-Pack</td>
-    <td><!--Short Description-->Soundcloud, twitch and youtube</td> 
-    <td><!--Chrome Link--><a href="https://chrome.google.com/webstore/detail/discord-rpc-pack/bdeelgdodbhgcablahbafehccghhpimj"><img src="https://www.google.com/s2/favicons?domain=chrome.google.com"></a></td> 
-    <td><a href="https://addons.mozilla.org/firefox/addon/discord-rpc-pack/"><img src="https://www.google.com/s2/favicons?domain=www.mozilla.org/de/firefox"></a><!--Firefox Link--></td>
-    <td><!--SourceCode Link--><a href="https://github.com/lolamtisch/Discord-RPC-Pack"><img src="https://www.google.com/s2/favicons?domain=github.com"></a></td>
-  </tr>
-  <tr>
-    <td><!--Title-->Mal-Sync</td>
-    <td><!--Short Description-->30+ Anime and manga pages</td> 
-    <td><!--Chrome Link--><a href="https://chrome.google.com/webstore/detail/mal-sync/kekjfbackdeiabghhcdklcdoekaanoel"><img src="https://www.google.com/s2/favicons?domain=chrome.google.com"></a></td> 
-    <td><a href="https://addons.mozilla.org/en-US/firefox/addon/mal-sync"><img src="https://www.google.com/s2/favicons?domain=www.mozilla.org/de/firefox"></a><!--Firefox Link--></td>
-    <td><!--SourceCode Link--><a href="https://github.com/lolamtisch/MALSync"><img src="https://www.google.com/s2/favicons?domain=github.com"></a></td>
-  </tr>
-  <tr>
-    <td><!--Title-->StadiaRPC</td>
-    <td><!--Short Description-->RPC presence for google stadia</td> 
-    <td><!--Chrome Link--><a href="https://chrome.google.com/webstore/detail/stadiarpc/dmhhgpkmilabgjpdbkinimkihdiobljg"><img src="https://www.google.com/s2/favicons?domain=chrome.google.com"></a></td> 
-    <td></a><!--Firefox Link--></td>
-    <td><!--SourceCode Link--><a href="https://github.com/soap-less/StadiaRPC"><img src="https://www.google.com/s2/favicons?domain=github.com"></a></td>
-  </tr>
-</table>
+# Compatible Extensions
+
+Here you can find a complete list of all extensions compatible with Discord-RPC-Extension. Feel free to submit [your extension](https://github.com/lolamtisch/Discord-RPC-Extension/blob/master/docs/api.md) here
+
+## Discord-RPC-Pack
+
+Presence pack for Youtube, Twitch and Soundcloud.
+
+[Chrome](https://chrome.google.com/webstore/detail/discord-rpc-pack/bdeelgdodbhgcablahbafehccghhpimj) | [Firefox](https://addons.mozilla.org/firefox/addon/discord-rpc-pack/) | [Github](https://github.com/lolamtisch/Discord-RPC-Pack)
+
+## MAL-Sync
+
+Integrates MyAnimeList into various sites, with auto episode tracking. Supports Rich Presence.
+
+[Chrome](https://chrome.google.com/webstore/detail/mal-sync/kekjfbackdeiabghhcdklcdoekaanoel) | [Firefox](https://addons.mozilla.org/en-US/firefox/addon/mal-sync/) | [Github](https://github.com/MALSync/MALSync)
+
+## StadiaRPC
+
+Presence for Google Stadia.
+
+[Chrome](https://chrome.google.com/webstore/detail/stadiarpc/dmhhgpkmilabgjpdbkinimkihdiobljg) | [Github](https://github.com/soap-less/StadiaRPC)


### PR DESCRIPTION
In this PR I completely redesigned layout of `extensions.md` to be easier to expand and read.
- Changed layout from HTML to Markdown
- Divided extensions intro headers rather than table cells
- Changed links intro text ones rather than image ones
- Slightly tweaked descriptions