### PR TITLE
Update api.md

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,17 @@ chrome.runtime.sendMessage(extensionId, {mode: 'active'}, function(response) {
   console.log('Presence registred')
 });
 ```
-The registration is only needed to be executed once for the extension to know that the presence exists. The presence is requested every 15 seconds, but if some change happens the presence can be forced to update through calling the registration again.
+The registration is only needed to be executed once for the extension to know that the presence exists. The presence is requested every 15 seconds, but if some change happens the presence can be forced to update through calling the registration again. If you wish for the timestamp to not be resetted every 15 seconds, consider storing `Date.now()` in a variable, and use that variable as the timestamp.
+
+The extensionId is the ID of the Discord-RPC extension. You will need to check what browser you are in, and change accordingly.
+```JS
+let extensionId = "agnaejlkbiiggajjmnpmeheigkflbnoo"; //Chrome
+if(typeof browser !== 'undefined' && typeof chrome !== "undefined"){
+  extensionId = "{57081fef-67b4-482f-bcb0-69296e63ec4f}"; //Firefox
+}
+```
+This needs to be above the registration code block.
+
 ### Modes
 There are 2 different presence types that can be registered. You have to pass it during the registration.
 #### active


### PR DESCRIPTION
Included the extensionId info (chrome and firefox extensionId and making sure that the extensionId is the Discord RPC id not the user's extension Id) and added a bit of clarity to how not to get the timestamp to be resetted every 15 seconds.